### PR TITLE
Update to resolver.py to use the new / correct name for the latest version of pyradiodns

### DIFF
--- a/src/odr/radiodns/resolver.py
+++ b/src/odr/radiodns/resolver.py
@@ -111,7 +111,7 @@ def resolve_dns(services):
 	for service in services:
 		bearer = service["bearer"]
 		try: 
-			result = radiodns.lookupDABService("%X" % ((bearer.eid >> 4 & 0xf00) + bearer.ecc), "%X" % bearer.eid, "%X" % bearer.sid, "%X" % bearer.scids)
+			result = radiodns.lookup_dab("%X" % ((bearer.eid >> 4 & 0xf00) + bearer.ecc), "%X" % bearer.eid, "%X" % bearer.sid, "%X" % bearer.scids)
 		except:
 			result = None
 		service["dns"] = result


### PR DESCRIPTION
Matches the version of pyradiodns from https://github.com/radiodns/pyradiodns (not the earlier version in PIP)